### PR TITLE
Add table support in FormattedText editor (Quill)

### DIFF
--- a/app/assets/stylesheets/modules/table.scss
+++ b/app/assets/stylesheets/modules/table.scss
@@ -46,7 +46,7 @@ table[table_id] {
   border-collapse: collapse;
 }
 td[cell_id] {
-  border: 1px solid black;
+  border: 1px solid #ddd !important;
   padding: 0px 5px;
   line-height: normal;
 }

--- a/app/assets/stylesheets/modules/table.scss
+++ b/app/assets/stylesheets/modules/table.scss
@@ -39,3 +39,17 @@ table.endnotes td p {
 table.endnotes td p:nth-of-type(1) {
   margin: 0;
 }
+
+// style for Quill table module
+table[table_id] {
+  width: 100%;
+  border-collapse: collapse;
+}
+td[cell_id] {
+  border: 1px solid black;
+  padding: 0px 5px;
+  line-height: normal;
+}
+td[cell_id] p {
+  margin: 5px;
+}

--- a/app/javascript/bundles/FormattedTextEditor/components/FormattedTextEditor.jsx
+++ b/app/javascript/bundles/FormattedTextEditor/components/FormattedTextEditor.jsx
@@ -15,6 +15,9 @@ import "../modules/footnote";
 import "../modules/endnote";
 import Noties from "../modules/noties";
 
+// Table module for Quill
+import "../modules/table";
+
 // Ajax library for uploading DOCX files
 import axios from 'axios';
 
@@ -81,6 +84,7 @@ class FormattedTextEditor extends React.Component {
         [{ 'script': 'sub'}, { 'script': 'super' }],
         ['link', 'image'],
         [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+        [{ table: FormattedTextEditor.tableOptions() }, { table: 'append-row' }, { table: 'append-col' }],
         ['footnote', 'endnote', 'import_docx'],
       ],
       handlers: {
@@ -129,6 +133,7 @@ class FormattedTextEditor extends React.Component {
       modules: {
         clipboard: true,
         toolbar: this.toolbarOptions,
+        table: true
       },
       theme: 'snow',
     });
@@ -305,6 +310,17 @@ class FormattedTextEditor extends React.Component {
   // handleNoteTextChange(e){
   //   this.setState({noteText: e.target.value});
   // }
+
+  // Return options array for Quill table module
+  static tableOptions(maxRows = 10, maxCols = 5){
+    let tableOptions = [];
+    for (let r = 1; r <= maxRows; r++) {
+      for (let c = 1; c <= maxCols; c++) {
+        tableOptions.push('newtable_' + r + '_' + c);
+      }
+    }
+    return tableOptions;
+  }
 
   render(){
     // onChange={this.handleNoteTextChange} value={this.state.noteText}

--- a/app/javascript/bundles/FormattedTextEditor/modules/table.js
+++ b/app/javascript/bundles/FormattedTextEditor/modules/table.js
@@ -1,0 +1,10 @@
+import Quill from "quill";
+import QuillTable from "quill-table";
+
+import "quill-table/src/css/quill.table.css";
+
+Quill.register(QuillTable.TableCell);
+Quill.register(QuillTable.TableRow);
+Quill.register(QuillTable.Table);
+Quill.register(QuillTable.Contain);
+Quill.register('modules/table', QuillTable.TableModule);

--- a/app/presenters/field/text_presenter.rb
+++ b/app/presenters/field/text_presenter.rb
@@ -91,7 +91,8 @@ class Field::TextPresenter < FieldPresenter
   def sanitize(v)
     @white_list_sanitizer ||= Rails::Html::WhiteListSanitizer.new
     # @white_listed_tags ||= Loofah::HTML5::WhiteList::ALLOWED_ELEMENTS_WITH_LIBXML2
-    @white_listed_attrs ||= Loofah::HTML5::WhiteList::ALLOWED_ATTRIBUTES.add('data-note')
-    safe_join([@white_list_sanitizer.sanitize(v, attributes: @white_listed_attrs).html_safe])
+    @white_listed_attrs ||= Loofah::HTML5::WhiteList::ALLOWED_ATTRIBUTES + %w[data-note table_id row_id cell_id]
+    @white_listed_tags ||= Loofah::HTML5::WhiteList::ALLOWED_ELEMENTS
+    safe_join([@white_list_sanitizer.sanitize(v, tags: @white_listed_tags, attributes: @white_listed_attrs).html_safe])
   end
 end

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-sass": "^4.7.2",
     "prop-types": "^15.6.0",
     "quill": "^1.3.4",
+    "quill-table": "^1.0",
     "react": "^16.1.1",
     "react-color": "^2.13.8",
     "react-dom": "^16.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,6 +493,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-add-module-exports@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz#9ae9a1f4a8dc67f0cdec4f4aeda1e43a5ff65e25"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
@@ -4596,6 +4600,13 @@ quill-delta@^3.6.2:
     deep-equal "^1.0.1"
     extend "^3.0.1"
     fast-diff "1.1.2"
+
+quill-table@^1.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/quill-table/-/quill-table-1.0.0.tgz#b7938dc5dfb03431b570893016f721b10d119de1"
+  dependencies:
+    babel-plugin-add-module-exports "^0.2.1"
+    babel-runtime "^6.26.0"
 
 quill@^1.3.4:
   version "1.3.4"


### PR DESCRIPTION
To be noted

[quilljs-table](https://github.com/dost/quilljs-table) is not under heavy development and has still [some issues](https://github.com/dost/quilljs-table#known-issues)