### PR TITLE
Keep raw value for non-array/non-hash values (fixes #85)

### DIFF
--- a/app/models/data_store/json_attribute.rb
+++ b/app/models/data_store/json_attribute.rb
@@ -86,8 +86,6 @@ class DataStore::JsonAttribute
 
   def generate_json(data)
     return nil if data.nil?
-
-    data = { "raw_value" => data } if !data.is_a?(Array) && !data.is_a?(Hash)
     JSON.pretty_generate(data)
   end
 end

--- a/test/models/data_store/json_attribute_test.rb
+++ b/test/models/data_store/json_attribute_test.rb
@@ -15,13 +15,9 @@ class DataStore::JsonAttributeTest < ActiveSupport::TestCase
     @item.respond_to?(:name_json)
   end
 
-  test "reader provides existing non-array, non-hash value as raw_value" do
+  test "reader does not transform existing non-array, non-hash values" do
     @item.name = "foo"
-    assert_equal(<<~TEXT.strip, @item.name_json)
-      {
-        "raw_value": "foo"
-      }
-    TEXT
+    assert_equal('"foo"', @item.name_json)
   end
 
   test "writer is defined" do


### PR DESCRIPTION
With this change non-hash and non-array values are not altered anymore for the JSON representation. This fixes the bug outlined in issue #85. If any data has been altered so far, it does not display properly anymore in the public catalog. However, the ReferenceEditor in data edit mode will still recognize the raw_data hash representation correctly.