### PR TITLE
Fix reference fields being displayed under the map component

### DIFF
--- a/app/assets/stylesheets/modules/form.scss
+++ b/app/assets/stylesheets/modules/form.scss
@@ -99,7 +99,7 @@ button[data-active=true]:focus {
 }
 
 .referenceEditor .css-15k3avv {
-    z-index: 3;
+    z-index: 1001;
     text-align: left;
 }
 


### PR DESCRIPTION
The Geomap component has `z-index` css properties with values such as `400`, `800` and `1000`.

We increased the `z-index` css property of reference fields to `1001`