### PR TITLE
Fix primary fields being displayed with their ids 

### DIFF
--- a/app/models/field/choice_set.rb
+++ b/app/models/field/choice_set.rb
@@ -109,7 +109,7 @@ class Field::ChoiceSet < ::Field
 
   def field_value_for_item(it)
     if multiple?
-      selected_choices(it).map(&:long_display_name)
+      selected_choices(it).map(&:long_display_name).join(', ')
     else
       ch = selected_choice(it)
       ch.nil? ? nil : ch.long_display_name

--- a/app/models/field/reference.rb
+++ b/app/models/field/reference.rb
@@ -94,7 +94,7 @@ class Field::Reference < ::Field
   def field_value_for_item(it)
     refs = value_for_item(it)
     if multiple?
-      refs.map(&:default_display_name)
+      refs.map(&:default_display_name).join(', ')
     else
       refs.nil? ? nil : refs.default_display_name
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -147,6 +147,8 @@ class Item < ApplicationRecord
     field = field_for_select
     return '' if field.nil?
 
+    return field.field_value_for_item(self) if primary_field_and_reference_or_choice_set?(field)
+
     field.strip_extra_content(self, locale)
   end
 
@@ -166,5 +168,9 @@ class Item < ApplicationRecord
 
   def update_views_cache
     ItemsCacheWorker.perform_async(catalog.slug, item_type.slug, id)
+  end
+
+  def primary_field_and_reference_or_choice_set?(field)
+    field == primary_field && (field.is_a?(Field::ChoiceSet) || field.is_a?(Field::Reference))
   end
 end


### PR DESCRIPTION
This fix applies for choice sets and references which where set as a primary field for an item type.

Single and multiple values are supported!

Multiple values are separated by a comma (`,`)