### PR TITLE
Fix reference editor display in data edition

### DIFF
--- a/app/presenters/field/reference_presenter.rb
+++ b/app/presenters/field/reference_presenter.rb
@@ -17,20 +17,29 @@ class Field::ReferencePresenter < FieldPresenter
   end
 
   def reference_control(method)
-    react_component(
-      'ReferenceEditor',
-      props: {
-        srcRef: "item_#{method}_json",
-        srcId: method,
-        multiple: field.multiple,
-        req: field.required,
-        category: field.category_id,
-        catalog: field.catalog.slug,
-        itemType: field.related_item_type.slug,
-        locale: I18n.locale
-      },
-      prerender: false
-    )
+    category = field.belongs_to_category? ? "data-field-category=\"#{field.category_id}\"" : ''
+    [
+      '<div class="form-component">',
+        "<div class=\"row\" #{category} data-field=\"#{field.id}\">",
+          '<div class="col-xs-12">',
+          react_component(
+            'ReferenceEditor',
+            props: {
+              srcRef: "item_#{method}_json",
+              srcId: method,
+              multiple: field.multiple,
+              req: field.required,
+              category: field.category_id,
+              catalog: field.catalog.slug,
+              itemType: field.related_item_type.slug,
+              locale: I18n.locale
+            },
+            prerender: false
+          ),
+          '</div>',
+        '</div>',
+      '</div>'
+    ].join.html_safe
   end
 
   def value


### PR DESCRIPTION
Fix for [#103](https://github.com/catima/catima/issues/113) 

Reference editor is now displayed correctly when category condition is not met