### PR TITLE
Fix bug where selected reference would not appear in reference edittor

### DIFF
--- a/app/javascript/bundles/ReferenceEditor/components/ReferenceEditor.jsx
+++ b/app/javascript/bundles/ReferenceEditor/components/ReferenceEditor.jsx
@@ -87,6 +87,7 @@ class ReferenceEditor extends Component {
                 fields={this.state.fields}
                 searchPlaceholder={this.state.selectPlaceholder}
                 filterPlaceholder={this.state.filterPlaceholder}
+                selectedReference={this.props.selectedReferences}
                 loadingMessage={this.state.loadingMessage}
                 srcRef={this.props.srcRef}
                 srcId={this.props.srcId}

--- a/app/javascript/bundles/ReferenceEditor/components/SingleReferenceEditor.jsx
+++ b/app/javascript/bundles/ReferenceEditor/components/SingleReferenceEditor.jsx
@@ -45,7 +45,7 @@ class SingleReferenceEditor extends Component {
 
   _load(v){
     if (v !== null && v !== '') {
-      let initItem = this.props.items.filter(item => item.id === parseInt(JSON.parse(v)));
+      let initItem = this.props.selectedReference;
       if(initItem.length === 1) return this._getJSONItem(initItem[0]);
     }
     return [];


### PR DESCRIPTION
Previously selected reference is now displayed even if it has not been paginated yet