### PR TITLE
Fix default values overriding custom values for new item

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -198,7 +198,10 @@ class Item < ApplicationRecord
 
     self.data = {} if data.nil?
     fields.each do |f|
-      self.data[f.uuid] = f.default_value if f.default_value.present? && !data.key?(f.uuid)
+      next unless f.default_value.present?
+      next if data.key?(f.uuid)
+
+      self.data[f.uuid] = f.default_value
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -198,7 +198,10 @@ class Item < ApplicationRecord
 
     self.data = {} if data.nil?
     fields.each do |f|
-      next unless f.default_value.present?
+      next if f.default_value.blank?
+
+      # In some cases, data are already setted when this assignation occurs.
+      # In these cases, we do not override already setted data.
       next if data.key?(f.uuid)
 
       self.data[f.uuid] = f.default_value

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -198,7 +198,7 @@ class Item < ApplicationRecord
 
     self.data = {} if data.nil?
     fields.each do |f|
-      self.data[f.uuid] = f.default_value if f.default_value.present?
+      self.data[f.uuid] = f.default_value if f.default_value.present? && !data.key?(f.uuid)
     end
   end
 

--- a/test/fixtures/fields.yml
+++ b/test/fixtures/fields.yml
@@ -114,6 +114,7 @@ one_author_age:
   uuid: one_author_age_uuid
   display_in_public_list: false
   row_order: 2
+  default_value: "50"
 
 one_author_site:
   type: "Field::URL"
@@ -332,6 +333,16 @@ one_author_media:
   uuid: one_author_media_uuid
   required: false
   options: { "format":"iframe", "domains":'[{"label":"Youtube.com (www.youtube.com)","value":"www.youtube.com"}]' }
+
+one_author_favorite_color:
+  type: "Field::Text"
+  name_translations: { "name_en": "Favorite Color"}
+  name_plural_translations: { "name_plural_en": "Favorite Colors" }
+  slug: favorite_color
+  field_set: one_author (ItemType)
+  uuid: one_author_favorite_color_uuid
+  required: false
+  default_value: "Vert"
 
 one_book_title:
   type: "Field::Text"

--- a/test/integration/catalog_admin/items_test.rb
+++ b/test/integration/catalog_admin/items_test.rb
@@ -42,6 +42,7 @@ class CatalogAdmin::ItemsTest < ActionDispatch::IntegrationTest
     assert_equal("25", author.public_send(:one_author_age_uuid).to_s)
     assert_equal("https://google.com/", author.public_send(:one_author_site_uuid))
     assert_equal("1.25", author.public_send(:one_author_rank_uuid))
+    assert_equal("Vert", author.public_send(:one_author_favorite_color_uuid))
     assert_equal(choices(:one_english).id.to_s, author.public_send(:one_author_language_uuid).to_s)
     assert_equal(
       [choices(:one_english).id.to_s, choices(:one_spanish).id.to_s],


### PR DESCRIPTION
Note: the same problem could happens with "assign_autoincrement_values" callback, but the case was already taken care with the same logic than this fix.

Add two tests:
 - One for testing that default values are correctly setted.
 - One for testing that default values don't override custom value.