### PR TITLE
Allow to run tests inside docker container

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ end
 group :development, :test do
   gem "simplecov", "~> 0.20", :require => false
   gem "byebug", "~> 11.1.3"
+  gem "webdrivers", "~> 4.4"
+  gem "selenium-webdriver", "~> 3.142"
 end
 
 group :development do
@@ -106,7 +108,6 @@ end
 
 group :test do
   gem "capybara", "~> 3.34"
-  gem "webdrivers", "~> 4.4"
   gem "connection_pool", "~> 2.2"
   gem "json_schema", "~> 0.20"
   gem "launchy", "~> 2.5"
@@ -114,7 +115,6 @@ group :test do
   gem "mocha", "~> 1.11"
   gem "puma", "~> 5.6"
   gem "pry", "~> 0.13"
-  gem "selenium-webdriver", "~> 3.142"
   gem "shoulda-context", "~> 2.0"
   gem "shoulda-matchers", "~> 5.1"
   gem "vcr", "~> 6.0"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,16 @@ Or to get the messages in JSON format.
 
 ## Tests & API specs
 
+### Local
 * To run the full suite, run `rails test`
 * To run a single test, specify the line with `rails test path/to/file:line_number`
 * To view the integration tests running in the browser prepend `HEADLESS=0` to the commands above
 * To run API requests specs and generate API doc `rails swag:run`. The API doc is not versioned and should be added to the project during deployment.
+
+### Docker
+* To run the full suite, run `docker exec -it -e NO_COVERAGE=1 catima-app bin/rails test`.
+* To run a single test, specify the line with `docker exec -it -e NO_COVERAGE=1 catima-app bin/rails test path/to/file:line_number`.
+* To run without coverage (improve performances), add `-e NO_COVERAGE=1` to `docker exec` args.
+* To view the integration tests running in the browser, add `-e HEADLESS=0` to `docker exec` args, then connect to the vnc server with "secret" as password:
+  * Go to [http://127.0.0.1:4444](http://127.0.0.1:4444), click on Sessions, you should see a line corresponding to the running tests and a camera icon next to it, click on it to open a vnc viewer.
+  * On Mac, open Finder and press `⌘ + K`, enter [vnc://localhost:5900](vnc://localhost:5900) as the server address and click Connect. This Mac utility allows you to interact with the browser. Putting a sleep in the tests code can be useful to get some time between each tests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     ports:
       - "8383:3000"
       - "1234:1234"
+    expose:
+      - "4000"
     depends_on:
       catima-postgres:
         condition: service_healthy
@@ -99,6 +101,21 @@ services:
     networks:
       - catima-net
     container_name: catima-mailhog
+  catima-selenium:
+    image: "seleniarm/standalone-chromium:latest"
+    shm_size: "2gb"
+    ports:
+      - "127.0.0.1:4444:4444"
+      - "127.0.0.1:5900:5900"
+    networks:
+      - catima-net
+    healthcheck:
+      test: /opt/bin/check-grid.sh --host 0.0.0.0 --port 4444
+      interval: 20s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    container_name: catima-selenium
 
 volumes:
   redis-data:


### PR DESCRIPTION
There are still one error remaining with attachment file.

ERROR CatalogAdmin::ItemsTest#test_import_items_from_CSV (175.05s) Minitest::UnexpectedError:
ArgumentError: Selenium < 3.14 with remote Chrome doesn't support multiple file upload
test/integration/catalog_admin/csv_imports_test.rb:10:in `block in <class:ItemsTest>'