### PR TITLE
Fix filterable for summary

### DIFF
--- a/app/assets/javascripts/catalog-admin/fields.coffee
+++ b/app/assets/javascripts/catalog-admin/fields.coffee
@@ -2,6 +2,9 @@ is_checked = (field_id) ->
   $field = $("##{field_id}")
   $field.length && $field[0].checked
 
+not_filterable = ->
+  !JSON.parse($("#field_filterable").val())
+
 manage_states = ->
   # Enable or disable fields according to their "policies" (see fields_disabled_policies).
   for field_id, func_should_be_disabled of fields_disabled_policies
@@ -18,13 +21,12 @@ manage_states = ->
 # must be enabled or disabled as value.
 fields_disabled_policies = {
   field_formatted_text: ->
-    is_checked('field_primary') || is_checked('field_display_in_public_list')
+    is_checked('field_primary')
   ,
   field_primary: ->
     is_checked('field_formatted_text') || is_checked('field_restricted')
   ,
   field_restricted: -> is_checked('field_primary'),
-  field_display_in_public_list: -> is_checked('field_formatted_text'),
   field_default_value: -> is_checked('field_auto_increment')
 }
 

--- a/app/helpers/catalog_admin/fields_option_helper.rb
+++ b/app/helpers/catalog_admin/fields_option_helper.rb
@@ -14,6 +14,8 @@ module CatalogAdmin::FieldsOptionHelper
     # not human readable.
     return true if field.is_a?(Field::Image)
 
+    return true if field.filterable?
+
     false
   end
 

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -228,9 +228,11 @@ class Field < ApplicationRecord
 
   # Whether or not this field can be displayed in the public list view.
   # Override for allowing a field to be displayed in the public list view
-  # although it's not human readable.
+  # although it's not human readable nor filterable.
   def displayable_in_public_list?
-    human_readable?
+    return true if human_readable?
+
+    return true if filterable?
   end
 
   def raw_value(item, locale=I18n.locale, suffix="")

--- a/app/views/catalog_admin/fields/edit.html.erb
+++ b/app/views/catalog_admin/fields/edit.html.erb
@@ -6,6 +6,7 @@
       :url => { :action => :update }
       ) do |f| %>
   <%= render("common_form_fields", :f => f) %>
+  <%= f.hidden_field(:filterable?) %>
 <% end %>
 
 <%= render_catalog_admin_fields_modals(@field) %>

--- a/db/migrate/20221221153045_disable_field_public_list_view_if_formatted_text.rb
+++ b/db/migrate/20221221153045_disable_field_public_list_view_if_formatted_text.rb
@@ -4,6 +4,10 @@ class DisableFieldPublicListViewIfFormattedText < ActiveRecord::Migration[6.1]
   # The first version was not correct because it set "display_in_public_list" to
   # false to all image fields and should not have.
   #
+  # The second version was also incorrect. The filterable fields are still
+  # displayed in summary although they're not human readable.
+  # The formatting is removed when the field is displayed.
+  #
   # We must be careful that in-between the creation and the correction of this
   # migration, doing migrations will lead to incorrect data.
   #
@@ -14,6 +18,8 @@ class DisableFieldPublicListViewIfFormattedText < ActiveRecord::Migration[6.1]
     # must be human readable. Set this option to false if it's not the case.
     Field.where(display_in_public_list: true).find_each do |field|
       next if field.human_readable?
+
+      next if field.filterable?
 
       next if field.is_a?(Field::Image)
 

--- a/test/integration/catalog_admin/fields_disabled_test.rb
+++ b/test/integration/catalog_admin/fields_disabled_test.rb
@@ -8,13 +8,8 @@ class CatalogAdmin::FieldsDisabledTest < ActionDispatch::IntegrationTest
 
     visit("/one/en/admin/authors/fields/nickname/edit")
 
-    # "Include this field in site list view" is checked by default.
-    assert find("#field_formatted_text").disabled?
-
-    uncheck("Include this field in site list view")
     check("Use this as the primary field")
     assert find("#field_restricted").disabled?
-    assert find("#field_formatted_text").disabled?
 
     uncheck("Use this as the primary field")
     check("Restrict this field to catalog staff")
@@ -23,6 +18,5 @@ class CatalogAdmin::FieldsDisabledTest < ActionDispatch::IntegrationTest
     uncheck("Restrict this field to catalog staff")
     check("Has formatted text")
     assert find("#field_primary").disabled?
-    assert find("#field_display_in_public_list").disabled?
   end
 end

--- a/test/models/field_test.rb
+++ b/test/models/field_test.rb
@@ -64,15 +64,13 @@ class FieldTest < ActiveSupport::TestCase
     assert(field.valid?)
   end
 
-  test "fields can't be primary or in public list if not human readable" do
+  test "fields can't be primary if not human readable" do
     text_field = fields(:one_title)
     text_field.formatted_text = "1"
     text_field.primary = true
-    text_field.display_in_public_list = true
 
     assert(text_field.save!)
 
     refute(text_field.primary)
-    refute(text_field.display_in_public_list)
   end
 end


### PR DESCRIPTION
This PR require a partiel rollback of the migration `DisableFieldPublicListViewIfFormattedText`.

This is because we didn't take into account the fact that some fields can be filterable and these fields can still be displayed in public list view. The only type of fields concerned are the text fields. So we need to rollback all the `display_in_public_list_view` column to `FALSE` for these fields.

These query was created from the pre-prod deployment dump to get all the text fields id concerned. 
```sql
-- Rollback migration for text field.
UPDATE
	fields
SET
	display_in_public_list = TRUE
WHERE
	id IN (...);

-- Query used for retrieve the field ids.
SELECT
	fields.id
FROM
	fields
WHERE TRUE
	AND json_extract_path(fields.options, 'formatted_text')::jsonb ? '1'
	AND fields.display_in_public_list
 	AND fields.type = 'Field::Text'
ORDER BY
 	fields.id;
```

On top of that, some migrations fail because of model validation. They were migrations for text fields that require no action because these was rollback above.

We need to apply manually these migrations for the other fields type. See query below.

```sql
-- Apply migration for fields, wich are not text, that didn't passe the validation.
UPDATE fields SET fields.display_in_public_list = FALSE WHERE fields.id = ...; 
```