### PR TITLE
Ensure having scrollable content when "code view" is active

### DIFF
--- a/app/assets/stylesheets/modules/summernote.scss
+++ b/app/assets/stylesheets/modules/summernote.scss
@@ -33,3 +33,9 @@
   font-family: "summernote";
   src: url("summernote/src/font/summernote.eot?#iefix") format("embedded-opentype"), url("summernote/src/font/summernote.woff2") format("woff2"), url("summernote/src/font/summernote.woff") format("woff"), url("summernote/src/font/summernote.ttf") format("truetype");
 }
+
+// Ensure having scrollable content when "code view" is active
+
+.note-editor .note-codable {
+  overflow: auto !important;
+}


### PR DESCRIPTION
![screenshot 2024-05-22 at 17 01 39](https://github.com/catima/catima/assets/417818/2351852c-f272-4d53-afe1-423bff41bf9b)
