### PR TITLE
Fix code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/app/models/json_config.rb
+++ b/app/models/json_config.rb
@@ -41,7 +41,7 @@ class JsonConfig
   end
 
   def load(name)
-    JSON.parse(IO.read(find_file(name)))
+    JSON.parse(File.read(find_file(name)))
   end
 
   private


### PR DESCRIPTION
Fixes [https://github.com/catima/catima/security/code-scanning/1](https://github.com/catima/catima/security/code-scanning/1)

To fix the problem, we need to replace the use of `IO.read` with `File.read`. This change will mitigate the risk of arbitrary code execution by ensuring that the file reading operation does not interpret the file name as a shell command. The change should be made in the `load` method of the `JsonConfig` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
